### PR TITLE
Fix the faulty p-values in mouse

### DIFF
--- a/container/domain/nease/annotated_graph.py
+++ b/container/domain/nease/annotated_graph.py
@@ -1,4 +1,5 @@
 # This file is responsible for filtering the PPI graph based on DDI, ELM and PDB
+import ast
 import pickle
 import timeit
 
@@ -89,6 +90,8 @@ def filter_ppi_graph(ppis, ddi_graph, elm, pdb, Organism):
 
 def pathway_node_degree(annotated_ppi_graph, pathway_entrez):
     # get the degree of each node in the pathway
+    if not isinstance(pathway_entrez, list):
+        pathway_entrez = ast.literal_eval(pathway_entrez)
     degree = sum([val for _, val in annotated_ppi_graph.degree(pathway_entrez)])
     return degree
 

--- a/container/domain/nease/functions.py
+++ b/container/domain/nease/functions.py
@@ -316,9 +316,9 @@ def single_path_enrich(path_id, Pathways, g2edges, mapping, organism, only_DDIs,
             spliced_genes.append(Entrez_to_name(g, mapping_dict=entrez_name_map))
             spliced_genes_entrez.append(g)
             gene_association.append(g in path_genes_str)
-            num.append(str(a) + '/' + str(a + b))
-            affected_edges.append((', ').join([Entrez_to_name(x, mapping_dict=entrez_name_map) for x in edges]))
-            affected_edges_entrez.append((', ').join(edges))
+            num.append(f"{a}/{a+b} ({a/(a+b)*100:.2f}%)")
+            affected_edges.append(', '.join([Entrez_to_name(x, mapping_dict=entrez_name_map) for x in edges]))
+            affected_edges_entrez.append(', '.join(edges))
             p_val.append(p_value)
 
             # save affected edges
@@ -327,7 +327,7 @@ def single_path_enrich(path_id, Pathways, g2edges, mapping, organism, only_DDIs,
     Enrichment = pd.DataFrame(list(
         zip(spliced_genes, spliced_genes_entrez, gene_association, num, p_val, affected_edges, affected_edges_entrez)),
         columns=['Spliced genes', 'NCBI gene ID', 'Gene is known to be in the pathway',
-                 'Percentage of edges associated to the pathway', 'p_value',
+                 'Edges associated with the pathway (%)', 'p_value',
                  'Affected binding (edges)', 'Affected binding (NCBI)'])
 
     return Enrichment, G

--- a/container/domain/nease/functions.py
+++ b/container/domain/nease/functions.py
@@ -341,7 +341,7 @@ def edge_enrich(a, b, p, n):
     # function to calculate P value
     # test if affected edges by AS are significally enriched in a pathway
     # fisher exact test
-    # a+b affected adges, with a the one linked to pathway p
+    # a+b affected edges, with a the one linked to pathway p
     # p total degree of pathway p
     # n total edges in the ppi used.
 


### PR DESCRIPTION
Fixes the faulty p-values in mouse data (also human data, as it turns out) by ensuring the degree is read from a list of nodes rather than a string of nodes. 
Fixes #61 